### PR TITLE
Put parentheses inside precalculated macros

### DIFF
--- a/Libraries/Arduino/src/SparkFun_LED_8x7.h
+++ b/Libraries/Arduino/src/SparkFun_LED_8x7.h
@@ -40,8 +40,8 @@
 #define END_SPACE           8       // Number of blank columns after text
 #define COL_SIZE            7       // Number of LEDs in a single column
 #define ROW_SIZE            8       // Number of LEDs in a single row
-#define NUM_LEDS            COL_SIZE * ROW_SIZE
-#define ALL_BUT_LAST_COL    NUM_LEDS - COL_SIZE
+#define NUM_LEDS            (COL_SIZE * ROW_SIZE)
+#define ALL_BUT_LAST_COL    (NUM_LEDS - COL_SIZE)
 
 /* Global variables */
 


### PR DESCRIPTION
I was wondering why code like this: 

```
int nextIdx = (buffIdx + 1) % NUM_LEDS;
buffA[nextIdx] = 1;
buffA[buffIdx] = 0;

buffIdx = nextIdx;
```

made a dot crawl down the first column, instead of lighting up each pixel individually. Then I took another look at the NUM_LEDS macro :)
